### PR TITLE
Colon fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osu-bpdpc",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Osu beatmap parser, difficulty and performance calculator",
   "main": "index.js",
   "engines": {

--- a/src/Beatmap.js
+++ b/src/Beatmap.js
@@ -137,7 +137,11 @@ class Beatmap {
           break;
         }
         case "Metadata": {
-          let [key, value] = line.split(":").map(v => v.trim());
+          let [key, ...value] = line.split(":");
+
+          key = key.trim();
+          value = value.join(':').trim();
+          
           switch (key) {
             case "Title":
               beatmap[section][key] = value;


### PR DESCRIPTION
https://osu.ppy.sh/beatmapsets/425935#osu/927688

If you try to parse this map, you will get wrong title because of colon.
It should return "W:Wonder", but not "W".